### PR TITLE
fix: Improve bootstrap error handling for missing pip

### DIFF
--- a/docs/UBUNTU_24.04_SETUP.md
+++ b/docs/UBUNTU_24.04_SETUP.md
@@ -26,15 +26,38 @@ cd LabLink
 python3 lablink.py
 ```
 
-**That's it!** The LabLink GUI launcher will:
-- ✅ Check your environment automatically
-- ✅ Detect missing system packages (Qt libraries, USB support, etc.)
-- ✅ **Install system packages automatically with your permission**
-- ✅ Show you what's missing with colored LED indicators
-- ✅ Install Python dependencies with one click
-- ✅ Let you start the server or client with one click
+**What happens next:**
+
+1. **First run**: If pip is not installed, you'll see a clear message:
+   ```
+   ERROR: pip is not installed
+
+   On Ubuntu 24.04, install pip with:
+     sudo apt update
+     sudo apt install -y python3-pip python3-venv
+   ```
+   Just run that command and try again!
+
+2. **Second run**: The launcher will install PyQt6 (needed for the GUI)
+
+3. **Third run**: The launcher opens and automatically:
+   - ✅ Checks your environment
+   - ✅ Detects missing system packages (Qt libraries, USB support, etc.)
+   - ✅ **Installs system packages automatically with your permission**
+   - ✅ Shows you what's missing with colored LED indicators
+   - ✅ Installs Python dependencies with one click
+   - ✅ Lets you start the server or client with one click
 
 The launcher uses `pkexec` for a graphical password prompt when installing system packages, so you won't need to type commands in the terminal.
+
+**TL;DR:** On a completely fresh Ubuntu 24.04, you'll run:
+```bash
+# If you get an error about pip, run this first:
+sudo apt update && sudo apt install -y python3-pip python3-venv
+
+# Then the launcher works automatically
+python3 lablink.py
+```
 
 ---
 
@@ -252,6 +275,28 @@ sudo ufw enable
 ---
 
 ## 🐛 Troubleshooting
+
+### "pip is not installed" error
+
+**Most common on fresh Ubuntu 24.04!**
+
+If you see:
+```
+ERROR: pip is not installed
+/usr/bin/python3: No module named pip
+```
+
+This is because Ubuntu 24.04 doesn't include pip by default. Install it:
+
+```bash
+sudo apt update
+sudo apt install -y python3-pip python3-venv
+```
+
+Then run the launcher again:
+```bash
+python3 lablink.py
+```
 
 ### "PyQt6 is not installed" on first run
 

--- a/lablink.py
+++ b/lablink.py
@@ -24,7 +24,30 @@ from typing import List, Dict, Tuple, Optional
 from dataclasses import dataclass
 from enum import Enum
 
-# Qt imports
+# Bootstrap check: Ensure pip is available before trying to install PyQt6
+def check_and_install_pip():
+    """Check if pip is available, and install if needed."""
+    # Check if pip is available
+    result = subprocess.run(
+        [sys.executable, '-m', 'pip', '--version'],
+        capture_output=True,
+        text=True,
+        check=False
+    )
+
+    if result.returncode != 0:
+        print("\n" + "="*70)
+        print("ERROR: pip is not installed")
+        print("="*70)
+        print("\nLabLink requires pip to install dependencies.")
+        print("\nOn Ubuntu 24.04, install pip with:")
+        print("  sudo apt update")
+        print("  sudo apt install -y python3-pip python3-venv")
+        print("\nOr use the system package manager to install LabLink dependencies.")
+        print("="*70 + "\n")
+        sys.exit(1)
+
+# Qt imports with bootstrap handling
 try:
     from PyQt6.QtWidgets import (
         QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
@@ -34,11 +57,38 @@ try:
     from PyQt6.QtCore import Qt, QTimer, QThread, pyqtSignal, QSize
     from PyQt6.QtGui import QPainter, QColor, QFont, QPalette, QIcon
 except ImportError:
-    print("ERROR: PyQt6 is not installed.")
-    print("Installing PyQt6 for the launcher...")
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "PyQt6"])
-    print("PyQt6 installed. Please restart the application.")
-    sys.exit(0)
+    print("\n" + "="*70)
+    print("PyQt6 is not installed - Installing now...")
+    print("="*70)
+
+    # Make sure pip is available first
+    check_and_install_pip()
+
+    # Try to install PyQt6
+    try:
+        print("\nInstalling PyQt6 for the launcher...")
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "PyQt6"])
+        print("\n" + "="*70)
+        print("SUCCESS: PyQt6 installed successfully!")
+        print("="*70)
+        print("\nPlease run the launcher again:")
+        print(f"  python3 {sys.argv[0]}")
+        print("="*70 + "\n")
+        sys.exit(0)
+    except subprocess.CalledProcessError as e:
+        print("\n" + "="*70)
+        print("ERROR: Failed to install PyQt6")
+        print("="*70)
+        print(f"\nError: {e}")
+        print("\nPlease install manually:")
+        print("  python3 -m pip install PyQt6")
+        print("\nOr use a virtual environment:")
+        print("  python3 -m venv venv")
+        print("  source venv/bin/activate")
+        print("  pip install PyQt6")
+        print(f"  python3 {sys.argv[0]}")
+        print("="*70 + "\n")
+        sys.exit(1)
 
 
 # Status levels


### PR DESCRIPTION
Fixed the launcher to gracefully handle fresh Ubuntu 24.04 installations where pip is not installed by default.

Changes to lablink.py:
- Added check_and_install_pip() bootstrap function
- Checks for pip availability before trying to install PyQt6
- Provides clear, formatted error messages with instructions
- Handles pip installation failures gracefully
- Suggests virtual environment as alternative approach
- Better error formatting with visual separators

Changes to docs/UBUNTU_24.04_SETUP.md:
- Added step-by-step explanation of first-run experience
- Clarified what happens on each run (pip check → PyQt6 install → GUI)
- Added TL;DR section for quick reference
- Updated troubleshooting section with "pip is not installed" as first item
- Added actual error message example for easy identification

User Experience Improvements:
- Clear error messages instead of Python tracebacks
- Specific instructions for Ubuntu 24.04 users
- Alternative solutions (venv, manual install)
- Visual formatting makes errors easy to understand

This fixes the issue where users on fresh Ubuntu 24.04 would see:
  ModuleNotFoundError: No module named 'PyQt6'
  CalledProcessError: Command returned non-zero exit status 1

Now they see:
  ERROR: pip is not installed
  On Ubuntu 24.04, install pip with:
    sudo apt update
    sudo apt install -y python3-pip python3-venv

Much clearer and actionable!