### PR TITLE
feat: Add lablink-update command for easy code updates

### DIFF
--- a/lablink-update.sh
+++ b/lablink-update.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# LabLink Update Script
+# Updates code from git and rebuilds containers
+#
+# Usage: sudo ./lablink-update.sh [branch]
+# Example: sudo ./lablink-update.sh main
+
+BRANCH="${1:-main}"
+
+echo "╔═══════════════════════════════════════════════════════╗"
+echo "║                                                       ║"
+echo "║            LabLink Update & Rebuild                   ║"
+echo "║                                                       ║"
+echo "╚═══════════════════════════════════════════════════════╝"
+echo ""
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]; then
+    echo "Error: This script must be run as root (use sudo)"
+    exit 1
+fi
+
+cd /opt/lablink || exit 1
+
+echo "Step 1: Checking current version..."
+CURRENT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+echo "  Current branch: $CURRENT_BRANCH"
+echo "  Current commit: $CURRENT_COMMIT"
+echo ""
+
+echo "Step 2: Pulling latest code from git (branch: $BRANCH)..."
+if git fetch origin "$BRANCH" && git checkout "$BRANCH" && git pull origin "$BRANCH"; then
+    NEW_COMMIT=$(git rev-parse --short HEAD)
+    echo "  ✓ Code updated to: $NEW_COMMIT"
+
+    if [ "$CURRENT_COMMIT" = "$NEW_COMMIT" ]; then
+        echo "  Already up to date!"
+        read -p "Rebuild anyway? (y/N): " rebuild
+        if [ "$rebuild" != "y" ] && [ "$rebuild" != "Y" ]; then
+            echo "No rebuild needed. Exiting."
+            exit 0
+        fi
+    fi
+else
+    echo "  ✗ Git pull failed"
+    echo "  Continuing with rebuild anyway..."
+fi
+echo ""
+
+echo "Step 3: Stopping containers..."
+docker compose down
+echo ""
+
+echo "Step 4: Rebuilding containers (this may take 2-3 minutes)..."
+if docker compose build --no-cache; then
+    echo "  ✓ Rebuild successful"
+else
+    echo "  ✗ Rebuild failed"
+    echo "  Check logs above for errors"
+    exit 1
+fi
+echo ""
+
+echo "Step 5: Starting containers..."
+if docker compose up -d; then
+    echo "  ✓ Containers started"
+else
+    echo "  ✗ Failed to start containers"
+    exit 1
+fi
+echo ""
+
+echo "Step 6: Waiting for services to be ready..."
+sleep 5
+
+# Wait for containers to be healthy
+MAX_WAIT=30
+WAITED=0
+while [ $WAITED -lt $MAX_WAIT ]; do
+    if docker compose ps 2>/dev/null | grep -q "Up"; then
+        echo "  ✓ Services are ready"
+        break
+    fi
+    sleep 2
+    WAITED=$((WAITED + 2))
+done
+echo ""
+
+echo "╔═══════════════════════════════════════════════════════╗"
+echo "║            Update Complete!                           ║"
+echo "╚═══════════════════════════════════════════════════════╝"
+echo ""
+
+# Show final status if lablink-status exists
+if command -v lablink-status &> /dev/null; then
+    lablink-status
+else
+    echo "Container Status:"
+    docker compose ps
+fi


### PR DESCRIPTION
Adds a comprehensive update system to ensure Docker containers always reflect the latest code changes after git pull.

New features:

1. lablink-update command (installed on all new Pi images):
   - Automatically pulls latest code from git
   - Rebuilds Docker containers with --no-cache
   - Waits for services to be healthy
   - Shows before/after commit hashes
   - Skips rebuild if already up to date (with override option)
   - Displays final status

2. Standalone script (lablink-update.sh):
   - Can be run on existing Pis
   - Supports specifying branch: sudo ./lablink-update.sh main
   - Works even if lablink-update command not installed yet

3. Updated helper commands and documentation:
   - Added to lablink-status output
   - Added to MOTD (message of the day)
   - Added to first-boot completion message

Usage:
  # On Pi with new image:
  sudo lablink-update

  # On existing Pi:
  cd /opt/lablink
  curl -O https://raw.githubusercontent.com/X9X0/LabLink/main/lablink-update.sh
  chmod +x lablink-update.sh
  sudo ./lablink-update.sh

This solves the problem where git pull updates files but Docker containers continue running old code until manually rebuilt.