### PR TITLE
fix: Make Pi diagnostics run on host instead of inside container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,11 @@ services:
       # Configuration (optional - mount your own config)
       - ./config:/app/config:ro
 
+      # Pi-specific mounts for diagnostics (comment out these two lines for non-Pi development)
+      # These enable the Pi diagnostics feature to run scripts on the host system
+      - /var/run/docker.sock:/var/run/docker.sock:ro  # Docker API access
+      - /opt/lablink:/opt/lablink:ro  # Host LabLink directory
+
     environment:
       # Server configuration
       - LABLINK_HOST=0.0.0.0

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -30,6 +30,7 @@ psutil==5.9.8
 apscheduler==3.10.4
 zeroconf==0.132.2
 requests==2.32.4  # HTTP library for Pi discovery. Security: Fixes GHSA-9wx4-h78v-vm56 (cert verification), GHSA-9hjg-9r4m-mvj7 (netrc leak)
+docker==7.1.0  # Docker Python API for running Pi diagnostics on host
 
 # Testing
 pytest==7.4.4


### PR DESCRIPTION
Previously, the Pi diagnostics endpoint executed the diagnose-pi.sh script inside the Docker container, which didn't have access to host-level services like Docker, systemd, or the actual /opt/lablink directory. This resulted in incorrect diagnostic output showing the container ID as hostname and missing all host-level information.

Changes:
- docker-compose.yml: Added volume mounts for Docker socket and /opt/lablink to enable host access from within the container
- server/requirements.txt: Added docker==7.1.0 Python library for Docker API
- server/api/diagnostics.py: Rewrote endpoint to use Docker API with nsenter to execute the diagnostic script on the host system, not in the container

The new implementation:
1. Uses docker.containers.run() with pid_mode='host' and privileged=True
2. Runs an Alpine container with nsenter to break into host namespaces
3. Executes the diagnostic script in the host's mount/network/PID context
4. Returns actual host system information instead of container information

This ensures diagnostic output shows the real Pi hostname, Docker status, systemd services, and /opt/lablink directory contents.