### PR TITLE
fix: Generate deterministic equipment IDs to prevent 404 errors on reconnection

### DIFF
--- a/server/equipment/base.py
+++ b/server/equipment/base.py
@@ -1,6 +1,7 @@
 """Base class for all equipment."""
 
 import asyncio
+import hashlib
 import logging
 from abc import ABC, abstractmethod
 from typing import Any, Optional
@@ -12,6 +13,23 @@ from shared.models.equipment import (ConnectionType, EquipmentInfo,
                                      EquipmentStatus, EquipmentType)
 
 logger = logging.getLogger(__name__)
+
+
+def generate_equipment_id(resource_string: str, prefix: str) -> str:
+    """Generate a deterministic equipment ID from the resource string.
+
+    Args:
+        resource_string: The VISA resource string (e.g., "TCPIP::192.168.1.100::INSTR")
+        prefix: The prefix to use for the ID (e.g., "ps_", "scope_", "load_")
+
+    Returns:
+        A deterministic equipment ID (e.g., "ps_a1b2c3d4")
+    """
+    # Create a hash of the resource string
+    hash_obj = hashlib.sha256(resource_string.encode())
+    # Take first 8 characters of hex digest for a compact ID
+    hash_hex = hash_obj.hexdigest()[:8]
+    return f"{prefix}{hash_hex}"
 
 
 class BaseEquipment(ABC):

--- a/server/equipment/bk_power_supply.py
+++ b/server/equipment/bk_power_supply.py
@@ -122,7 +122,9 @@ class BKPowerSupplyBase(BaseEquipment):
             logger.warning(f"Could not query *IDN?, using defaults: {e}")
             # Use default values set in __init__
 
-        equipment_id = f"ps_{uuid.uuid4().hex[:8]}"
+        # Generate deterministic ID from resource string
+        from .base import generate_equipment_id
+        equipment_id = generate_equipment_id(self.resource_string, "ps_")
 
         # Initialize safety validator
         self._initialize_safety(equipment_id)

--- a/server/equipment/mock/mock_electronic_load.py
+++ b/server/equipment/mock/mock_electronic_load.py
@@ -72,7 +72,9 @@ class MockElectronicLoad:
 
     async def get_info(self) -> EquipmentInfo:
         """Get electronic load information."""
-        equipment_id = f"load_{uuid.uuid4().hex[:8]}"
+        # Generate deterministic ID from resource string
+        from ..base import generate_equipment_id
+        equipment_id = generate_equipment_id(self.resource_string, "load_")
 
         return EquipmentInfo(
             id=equipment_id,

--- a/server/equipment/mock/mock_oscilloscope.py
+++ b/server/equipment/mock/mock_oscilloscope.py
@@ -72,7 +72,9 @@ class MockOscilloscope:
 
     async def get_info(self) -> EquipmentInfo:
         """Get oscilloscope information."""
-        equipment_id = f"scope_{uuid.uuid4().hex[:8]}"
+        # Generate deterministic ID from resource string
+        from ..base import generate_equipment_id
+        equipment_id = generate_equipment_id(self.resource_string, "scope_")
 
         return EquipmentInfo(
             id=equipment_id,

--- a/server/equipment/mock/mock_power_supply.py
+++ b/server/equipment/mock/mock_power_supply.py
@@ -64,7 +64,9 @@ class MockPowerSupply:
 
     async def get_info(self) -> EquipmentInfo:
         """Get power supply information."""
-        equipment_id = f"ps_{uuid.uuid4().hex[:8]}"
+        # Generate deterministic ID from resource string
+        from ..base import generate_equipment_id
+        equipment_id = generate_equipment_id(self.resource_string, "ps_")
 
         return EquipmentInfo(
             id=equipment_id,

--- a/server/equipment/rigol_electronic_load.py
+++ b/server/equipment/rigol_electronic_load.py
@@ -35,7 +35,9 @@ class RigolDL3021A(BaseEquipment):
         model = parts[1] if len(parts) > 1 else self.model
         serial = parts[2] if len(parts) > 2 else None
 
-        equipment_id = f"load_{uuid.uuid4().hex[:8]}"
+        # Generate deterministic ID from resource string
+        from .base import generate_equipment_id
+        equipment_id = generate_equipment_id(self.resource_string, "load_")
 
         return EquipmentInfo(
             id=equipment_id,

--- a/server/equipment/rigol_scope.py
+++ b/server/equipment/rigol_scope.py
@@ -35,7 +35,9 @@ class RigolMSO2072A(BaseEquipment):
         model = parts[1] if len(parts) > 1 else self.model
         serial = parts[2] if len(parts) > 2 else None
 
-        equipment_id = f"scope_{uuid.uuid4().hex[:8]}"
+        # Generate deterministic ID from resource string
+        from .base import generate_equipment_id
+        equipment_id = generate_equipment_id(self.resource_string, "scope_")
 
         return EquipmentInfo(
             id=equipment_id,
@@ -253,7 +255,9 @@ class RigolDS1104(BaseEquipment):
         model = parts[1] if len(parts) > 1 else self.model
         serial = parts[2] if len(parts) > 2 else None
 
-        equipment_id = f"scope_{uuid.uuid4().hex[:8]}"
+        # Generate deterministic ID from resource string
+        from .base import generate_equipment_id
+        equipment_id = generate_equipment_id(self.resource_string, "scope_")
 
         return EquipmentInfo(
             id=equipment_id,
@@ -473,7 +477,9 @@ class RigolDS1102D(BaseEquipment):
         model = parts[1] if len(parts) > 1 else self.model
         serial = parts[2] if len(parts) > 2 else None
 
-        equipment_id = f"scope_{uuid.uuid4().hex[:8]}"
+        # Generate deterministic ID from resource string
+        from .base import generate_equipment_id
+        equipment_id = generate_equipment_id(self.resource_string, "scope_")
 
         return EquipmentInfo(
             id=equipment_id,


### PR DESCRIPTION
## Problem

Equipment IDs were being generated using random UUIDs (`uuid.uuid4()`), causing them to change every time a device reconnected or the server restarted. This resulted in 404 errors when clients tried to access equipment endpoints (like `/api/equipment/{equipment_id}/readings`) using stale IDs from before the reconnection.

**Example scenario:**
1. Device connects → assigned ID `ps_61ee82b9`
2. Client stores this ID and makes requests
3. Device disconnects/reconnects → assigned NEW ID `ps_a1b2c3d4`
4. Client requests to `/api/equipment/ps_61ee82b9/readings` → **404 Not Found**

## Solution

Implemented deterministic equipment ID generation using SHA256 hashing of the VISA resource string:

- Added `generate_equipment_id()` helper function in `server/equipment/base.py`
- Uses SHA256 hash of resource string to create stable, deterministic IDs
- Updated all equipment classes to use the new helper:
  - BK Precision power supplies
  - Rigol oscilloscopes (MSO2072A, DS1104, DS1102D)
  - Rigol electronic loads (DL3021A)
  - All mock equipment classes

**Result:** Equipment with resource string `ASRL/dev/ttyUSB0::INSTR` will **always** get ID `ps_56fdd3df`, regardless of reconnections or server restarts.

## Changes

- `server/equipment/base.py`: Added `generate_equipment_id()` function
- `server/equipment/bk_power_supply.py`: Use deterministic IDs
- `server/equipment/rigol_scope.py`: Use deterministic IDs (all 3 scope classes)
- `server/equipment/rigol_electronic_load.py`: Use deterministic IDs
- `server/equipment/mock/*.py`: Use deterministic IDs for all mock equipment

## Testing

Verified that equipment IDs remain stable:
```bash
# Connect device
→ {"equipment_id":"ps_56fdd3df","status":"connected"}

# Disconnect and reconnect
→ {"equipment_id":"ps_56fdd3df","status":"connected"}  # SAME ID ✓
