### PR TITLE
Fix equipment disconnect UI: proper success message and complete UI clearing

### DIFF
--- a/client/ui/equipment_panel.py
+++ b/client/ui/equipment_panel.py
@@ -609,7 +609,13 @@ class EquipmentPanel(QWidget):
                 # Clear selected equipment and UI
                 self.selected_equipment = None
                 self.readings_display.clear()
-                self.info_display.clear()
+                # Clear equipment detail labels
+                self.name_label.clear()
+                self.type_label.clear()
+                self.manufacturer_label.clear()
+                self.model_label.clear()
+                self.resource_label.clear()
+                self.status_label.clear()
                 self.refresh()
             else:
                 QMessageBox.warning(


### PR DESCRIPTION
## Summary

Fixes equipment disconnect showing error despite working, and ensures all UI elements are properly cleared after disconnect.

## Issues Fixed

### 1. Disconnect Shows "Failed" Despite Working

**Problem:**  
When clicking disconnect button:
- Equipment actually disconnected (disappeared from list)
- But UI showed "Disconnection failed" message
- Readings and equipment info remained populated

**Root Cause:**  
Server returns:
```json
{"equipment_id": "ps_56fdd3df", "status": "disconnected"}
