### PR TITLE
fix: Update PyQt6-Charts version to 6.6.0 for Ubuntu 24.04 compatibility

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,8 +1,8 @@
 # GUI Framework
 PyQt6==6.6.1
 PyQt6-Qt6==6.6.1
-PyQt6-Charts==6.6.1
-PyQt6-Charts-Qt6==6.6.1
+PyQt6-Charts==6.6.0
+PyQt6-Charts-Qt6==6.6.0
 pyqtgraph==0.13.3
 
 # Networking


### PR DESCRIPTION
PyQt6-Charts version 6.6.1 does not exist on PyPI. The available versions jump from 6.6.0 to 6.7.0. Updated both PyQt6-Charts and PyQt6-Charts-Qt6 to use version 6.6.0 which is compatible with PyQt6 6.6.1.

This resolves the pip installation failure on Ubuntu 24.04 deployments.