### PR TITLE
fix(client): Use dynamic version in About dialog

### DIFF
--- a/client/ui/main_window.py
+++ b/client/ui/main_window.py
@@ -649,10 +649,13 @@ class MainWindow(QMainWindow):
 
     def show_about(self):
         """Show about dialog."""
+        from PyQt6.QtWidgets import QApplication
+        version = QApplication.applicationVersion()
+
         QMessageBox.about(
             self,
             "About LabLink",
-            "<h2>LabLink v0.10.0</h2>"
+            f"<h2>LabLink v{version}</h2>"
             "<p>Laboratory Equipment Control and Data Acquisition System</p>"
             "<p>A modular client-server application for remote control and data "
             "acquisition from laboratory equipment.</p>"


### PR DESCRIPTION
Fixes #154

## Problem
- About dialog displayed hardcoded version "v0.10.0"  
- Version not updated when VERSION file changed
- Inconsistent with actual client version

## Solution
- Use `QApplication.applicationVersion()` to get current version
- Client already reads VERSION file in main.py and sets app version
- About dialog now dynamically displays the correct version

## Changes
- Modified `show_about()` method in `client/ui/main_window.py`
- Import QApplication and retrieve version at runtime
- Use f-string to inject version into dialog HTML

## Testing
- ✅ Help → About now shows "LabLink v1.2.3"
- ✅ Matches VERSION file content
- ✅ Will auto-update when version changes

## Impact
- About dialog shows correct, current version
- Single source of truth for versioning
- No manual updates needed when bumping versions